### PR TITLE
Add appProtocol for gRPC ports

### DIFF
--- a/charts/buildbuddy/Chart.yaml
+++ b/charts/buildbuddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Open Source
 name: buildbuddy
-version: 0.0.209 # Chart version
+version: 0.0.210 # Chart version
 appVersion: 2.44.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy/templates/service.yaml
+++ b/charts/buildbuddy/templates/service.yaml
@@ -25,24 +25,30 @@ spec:
       protocol: 'TCP'
       port: {{ .Values.service.externalGRPCPort }}
       targetPort: {{ .Values.service.internalGRPCPort }}
-    {{ if and .Values.service.externalHTTPSPort .Values.service.internalHTTPSPort }}
+      {{- if ge .Capabilities.KubeVersion.Minor "20" }}
+      appProtocol: kubernetes.io/h2c
+      {{- end }}
+    {{- if and .Values.service.externalHTTPSPort .Values.service.internalHTTPSPort }}
     - name: https
       protocol: 'TCP'
       port: {{ .Values.service.externalHTTPSPort }}
       targetPort: {{ .Values.service.internalHTTPSPort }}
-    {{ end }}
-    {{ if and .Values.service.externalGRPCSPort .Values.service.internalGRPCSPort }}
+    {{- end }}
+    {{- if and .Values.service.externalGRPCSPort .Values.service.internalGRPCSPort }}
     - name: grpcs
       protocol: 'TCP'
       port: {{ .Values.service.externalGRPCSPort }}
       targetPort: {{ .Values.service.internalGRPCSPort }}
-    {{ end }}
-    {{ if and .Values.service.externalMetricsPort .Values.service.internalMetricsPort }}
+      {{- if ge .Capabilities.KubeVersion.Minor "20" }}
+      appProtocol: kubernetes.io/h2c
+      {{- end }}
+    {{- end }}
+    {{- if and .Values.service.externalMetricsPort .Values.service.internalMetricsPort }}
     - name: metrics
       protocol: 'TCP'
       port: {{ .Values.service.externalMetricsPort }}
       targetPort: {{ .Values.service.internalMetricsPort }}
-    {{ end }}
+    {{- end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}


### PR DESCRIPTION
This allows ingresses other than nginx know that the service should receive HTTP/2 requests without needing for negotiation.